### PR TITLE
stop interpolation once all particles deposit/escape

### DIFF
--- a/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking.C
+++ b/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking.C
@@ -698,6 +698,15 @@ int main(int argc, char *argv[])
 	particleObject->OutputFile("siminhale_0000.csv");
     int StartNo = 2;
 
+        
+		if (argc > 4)
+		{
+				// update particle details from the file
+				int time = particleObject->UpdateParticleDetailsFromFile(argv[4]);
+				StartNo = time;
+				m = StartNo - 1;
+				img = m + 1;
+		}
 
 	// time loop starts
 	while (TDatabase::TimeDB->CURRENTTIME < end_time) // time cycle

--- a/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking.C
+++ b/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking.C
@@ -756,8 +756,8 @@ int main(int argc, char *argv[])
 				// Considering the simulation has saturated upto 1000 time  steps, If the particle moves more than 
 
                 int lineNo=0;
-				if(StartNo >  3995)
-					StartNo = 3995;
+				if(StartNo >  9995)
+					StartNo = 9995;
                 cout << "Start No : " << StartNo <<endl;
 				
                 // Read from the CSV value into solution array 
@@ -885,19 +885,35 @@ int main(int argc, char *argv[])
 					else
 						os << "VTK/" << VtkBaseName << "." << img << ".vtk" << ends;
 					Output->WriteVtk(os.str().c_str());
-					img++;
 				}
+				img++;
 				
                 if (m >= 20 )  // To start the interpolation after 20 time steps ( to ensure that flow has propogated )
                 {
                     cout << " Interpolation Started" <<endl;
                     //Compute the Particle Displacement for the FTLE values 
                     particleObject->interpolateNewVelocity_Parallel(TDatabase::TimeDB->TIMESTEPLENGTH,Velocity[0],Velocity_FeSpace[0]);
-                    std::string old_str = std::to_string(img-2);
-                    size_t n_zero = 4;
-                    auto new_str = std::string(n_zero - std::min(n_zero, old_str.length()), '0') + old_str;
-                    std::string name =  "siminhale_" + new_str + ".csv";
-                    particleObject->OutputFile(name.c_str());
+
+										std::string old_str = std::to_string(img-2);
+										size_t n_zero = 4;
+										auto new_str = std::string(n_zero - std::min(n_zero, old_str.length()), '0') + old_str;
+										std::string name =  "siminhale_" + new_str + ".csv";
+										if (m % 10 == 0)
+											particleObject->OutputFile(name.c_str());
+
+										int depositedCount = 0;
+										for (int i = 0; i < particleObject->isParticleDeposited.size(); i++) {
+											if (particleObject->isParticleDeposited[i]) depositedCount++;
+										}
+										if (depositedCount == numPart) {
+											cout << "All particles deposited/escaped" << endl;
+											cout << "Total particles: " << depositedCount << endl;
+											cout << "Particles deposited: " << depositedCount - particleObject->m_EscapedParticlesCount << endl;
+											cout << "Particles escaped: " << particleObject->m_EscapedParticlesCount << endl;
+											cout << "Error particles: " << particleObject->m_ErrorParticlesCount << endl;
+											cout << "Ghost particles: " << particleObject->m_ghostParticlesCount << endl;
+											break;
+										}
                 }
             }
 

--- a/include/FE/Particle.h
+++ b/include/FE/Particle.h
@@ -1,5 +1,5 @@
 #include<vector>
-
+#include<string>
 
 // Class of Mono Disperse Particles
 class TParticles
@@ -81,5 +81,8 @@ class TParticles
         void interpolateNewVelocity_Parallel(double timeStep,TFEVectFunct3D* VelocityFEVectFunction, TFESpace3D* fespace);
 
         void OutputFile(const char* filename);
-};
 
+				int UpdateParticleDetailsFromFile(std::string filename);
+
+				void printUpdatedParticleDetailStats();
+};

--- a/src/FE/Particle.C
+++ b/src/FE/Particle.C
@@ -1156,7 +1156,10 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
 
                 if (isBoundaryDOFPresent)  // Boundary DOF is present
                 {
-                    std::vector<double> boundaryDOF = m_BoundaryDOFsOnCell[cellNo];
+		    
+                    std::vector<double> boundaryDOF;
+		    #pragma omp critical
+		    boundaryDOF= m_BoundaryDOFsOnCell[cellNo];
 
                     position_X[i] = boundaryDOF[0];
                     position_Y[i] = boundaryDOF[1];

--- a/src/FE/Particle.C
+++ b/src/FE/Particle.C
@@ -1061,7 +1061,6 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
 
                 if (isBoundaryDOFPresent)  // Boundary DOF is present
                 {
-                    #pragma omp critical
                     std::vector<double> boundaryDOF = m_BoundaryDOFsOnCell[cellNo];
 
                     position_X[i] = boundaryDOF[0];

--- a/src/FE/Particle.C
+++ b/src/FE/Particle.C
@@ -405,6 +405,8 @@ void TParticles::OutputFile(const char *filename)
          << "escaped"
          << ","
          << "cell"
+         << ","
+         << "prevCell"
          << "\n";
     for (int i = 0; i < position_X.size(); i++)
     {
@@ -412,10 +414,103 @@ void TParticles::OutputFile(const char *filename)
         if (isParticleDeposited[i])
             depostionStatus = 1;
 
-        file << position_X[i] << "," << position_Y[i] << "," << position_Z[i] << "," << depostionStatus << "," << isErrorParticle[i] << "," << isEscapedParticle[i] << "," << currentCell[i] << "\n";
+        file << position_X[i] << "," << position_Y[i] << "," << position_Z[i] << "," << depostionStatus << "," << isErrorParticle[i] << "," << isEscapedParticle[i] << "," << currentCell[i] << "," << previousCell[i] << "\n";
     }
 
     file.close();
+}
+
+// Things not being considered: validity of the file, number of particles, ordering of the columns
+int TParticles::UpdateParticleDetailsFromFile(std::string filename)
+{
+		std::ifstream file(filename);
+    if (!file) {
+        std::cerr << "Failed to open the file." << std::endl;
+        return 1;
+    }
+
+		std::string line;
+		int counter = -1;
+
+    while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        std::string x_str, y_str, z_str, deposition_str, error_str, escaped_str, cell_str, prevCell_str;
+
+				if (counter == -1) {
+					counter++;
+					continue;
+				}
+
+        if (std::getline(iss, x_str, ',') &&
+            std::getline(iss, y_str, ',') &&
+            std::getline(iss, z_str, ',') &&
+            std::getline(iss, deposition_str, ',') &&
+            std::getline(iss, error_str, ',') &&
+            std::getline(iss, escaped_str, ',') &&
+            std::getline(iss, cell_str, ',') &&
+            std::getline(iss, prevCell_str)) {
+            try {
+								position_X[counter] = std::stod(x_str);
+								position_Y[counter] = std::stod(y_str);
+								position_Z[counter] = std::stod(z_str);
+								isParticleDeposited[counter] = std::stoi(deposition_str) == 1 ? true : false;
+								isErrorParticle[counter] = std::stoi(error_str) == 1 ? true : false;
+								isEscapedParticle[counter] = std::stoi(escaped_str) == 1 ? true : false;
+								currentCell[counter] = std::stoi(cell_str);
+								previousCell[counter] = std::stoi(prevCell_str);
+                counter++;
+            } catch (const std::exception& e) {
+                std::cerr << "Error parsing data: " << e.what() << std::endl;
+            }
+        } else {
+            std::cerr << "Invalid line format: " << line << std::endl;
+        }
+    }
+
+    file.close();
+
+    std::cout << "Data points read: " << counter << std::endl;
+
+		printUpdatedParticleDetailStats();
+
+		m_ParticlesReleased = counter;
+		cout << " Number of particles released : " << m_ParticlesReleased << endl;
+
+		// get substring containing the time from the filename
+		std::string time = filename.substr(filename.find_last_of("_") + 1);
+		time = time.substr(0, time.find("."));
+		// TDatabase::TimeDB->CURRENTTIME = std::stoi(time);
+
+		return std::stoi(time);
+}
+
+void TParticles::printUpdatedParticleDetailStats()
+{
+		int errorParticles = 0;
+		int escapedParticles = 0;
+		int depositedParticles = 0;
+		double normX = 0;
+		double normY = 0;
+		double normZ = 0;
+
+		for (int i = 0; i < position_X.size(); i++) {
+			if (isErrorParticle[i])
+				errorParticles++;
+			if (isEscapedParticle[i])
+				escapedParticles++;
+			if (isParticleDeposited[i])
+				depositedParticles++;
+			normX += position_X[i] * position_X[i];
+			normY += position_Y[i] * position_Y[i];
+			normZ += position_Z[i] * position_Z[i];
+		}
+
+		cout << " Number of error particles : " << errorParticles << endl;
+		cout << " Number of escaped particles : " << escapedParticles << endl;
+		cout << " Number of deposited particles : " << depositedParticles << endl;
+		cout << " Norm of x : " << normX << endl;
+		cout << " Norm of y : " << normY << endl;
+		cout << " Norm of z : " << normZ << endl;
 }
 
 // Helper Function


### PR DESCRIPTION
**Changes:**

`SiminhaleParticleTracking.C`
- Replace maximum `StartNo` with `9995` (i.e., assume steady state after that)
- Make solution output independant of vtk by moving `img++` out of the vtk loop
- Generate solution once every 10 timesteps
- Stop interpolation when all particles deposit/escape
- Print count of particles deposited, escaped, errored and ghost

`Particle.C`
- Remove `#pragma omp critical` from line `1064` as it is not required there