### PR TITLE
enable resuming particle simulation in gpu

### DIFF
--- a/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking_MPI.C
+++ b/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking_MPI.C
@@ -690,24 +690,15 @@ int main(int argc, char *argv[])
 
 	// INTIALISE THE PARTICLES 
     int numPart = std::atoi(argv[2]);
-	TParticles* particleObject =  new TParticles(numPart,0.0,0.0,0.01,Velocity_FeSpace[0]);
-	cout << " Particles Initialised " <<endl;
-
-
-
-	particleObject->OutputFile("siminhale_0000.csv");
     int StartNo = 2;
-		img = StartNo;
+    std::string resumeFile = (argc > 4) ? argv[4] : "";
 
-        
-		if (argc > 4)
-		{
-				// update particle details from the file
-				StartNo = particleObject->UpdateParticleDetailsFromFile(argv[4]);
-				StartNo = StartNo + 1;
-				img = StartNo;
-				m = StartNo - 2;
-		}
+	TParticles* particleObject =  new TParticles(numPart,0.0,0.0,0.01,Velocity_FeSpace[0], resumeFile, &StartNo);
+    cout << " Particles Initialised " <<endl;
+
+    particleObject->OutputFile("siminhale_0000.csv");
+	img = StartNo;
+    m = StartNo - 2;
 
 	// time loop starts
 	while (TDatabase::TimeDB->CURRENTTIME < end_time) // time cycle

--- a/include/FE/Particle.h
+++ b/include/FE/Particle.h
@@ -105,7 +105,7 @@ class TParticles
         // Position 
 
         //-- constructor--//
-        TParticles(int N_Particles, double circle_x, double circle_y, double radius, TFESpace3D *fespace);
+	TParticles(int N_Particles, double circle_x, double circle_y, double radius, TFESpace3D *fespace, std::string resumeFile, int *StartNo);
 
         // -- Methods to Initialise Particles -- //
         void  Initialiseparticles(int N_Particles,double circle_x, double circle_y, double radius,TFESpace3D* fespace);


### PR DESCRIPTION
## SiminhaleParticleTracking_MPI.C
- move resume from csv function call to `TParticles` constructor
- pass `resumeFile` to `TParticles` constructor
- pass address of `StartNo` to allow the `TParticles` constructor to update it

## Particle.h
- update the constructor to take `resumeFile` and `StartNo` as input

## Particle.C
- if the resumeFile is not an empty string, call the function to update particle details
- update `CURRENTTIME`
- use actual `cdcc` instead of `Re_p` as `L_inf`

## Particle.cu
- don't simulate particle if already deposited. This also fixes the output mismatch with openmp result