### PR TITLE
make stagnant particles detection parallel

### DIFF
--- a/UserConfig.cmake
+++ b/UserConfig.cmake
@@ -52,7 +52,7 @@ set(AParMooN_MPI_IMPLEMENTATION "INTELMPI" CACHE STRING "select the MPI Implemen
 # set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Fluid_Solutions_refined/" CACHE STRING "select the model")
 # set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Fluid_1LPM/" CACHE STRING "select the model")
 # set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Particle_Solutions_l_inf/" CACHE STRING "select the model")
-set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Particle_Testing" CACHE STRING "select the model")
+set(AParMooN_OUTPUT_DIR_PATH "../Output/Siminhale_Particle_Simulation" CACHE STRING "select the model")
 # set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/thivin3d" CACHE STRING "select the model")
 #set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/burger" CACHE STRING "select the model")
 # set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/cd1dANN" CACHE STRING "select the model")

--- a/include/FE/Particle.h
+++ b/include/FE/Particle.h
@@ -230,6 +230,11 @@ class TParticles
           double* d_m_particle_previous_position_y;
           double* d_m_particle_previous_position_z;
 
+          // Allocate Arrays for the particle previous position for stagnant particles
+          double* d_m_particle_stagnant_position_x;
+          double* d_m_particle_stagnant_position_y;
+          double* d_m_particle_stagnant_position_z;
+
           // Allocate memory for the particle velocity
           double* d_m_particle_velocity_x;
           double* d_m_particle_velocity_y;
@@ -340,6 +345,9 @@ class TParticles
 
           // Host wrapper for calling interpolate function
           void InterpolateVelocityHostWrapper(double timeStep,int N_Particles_released, int N_DOF, int N_cells);
+
+          // Host wrapper for detecting stagnant particles
+          void DetectStagnantParticlesHostWrapper(int N_Particles_released);
 
         #endif
 


### PR DESCRIPTION
## Particle.C
- use `openmp` to make the detection parallel
- call gpu host wrapper instead if `cuda` is enabled

## Particle.cu
- implement kernel function for stagnant particle detection
- implement host wrapper for the kernel function
## Particle.h
- add declaration for `previousPositions` inside device memory (gpu) for stagnant particle detection
- add declaration for a gpu host wrapper for detecting stagnant particles