### PR TITLE
Move particle properties declaration to run time

### DIFF
--- a/Main_Users/Thivin/Examples/TNSE3D/siminhale2.h
+++ b/Main_Users/Thivin/Examples/TNSE3D/siminhale2.h
@@ -184,6 +184,9 @@ void LinCoeffs(int n_points, double *X, double *Y, double *Z,
 			   double **parameters, double **coeffs)
 {
 	static double eps = 1. / TDatabase::ParamDB->RE_NR;
+	double velocityScale = TDatabase::ParamDB->VELOCITY_SCALE;
+	double lengthScale = TDatabase::ParamDB->LENGTH_SCALE;
+	double froudeNo = (velocityScale * velocityScale) / (9.81 * lengthScale);
 	int i;
 	double *coeff, x, y, z;
 	for (i = 0; i < n_points; i++)
@@ -191,8 +194,8 @@ void LinCoeffs(int n_points, double *X, double *Y, double *Z,
 		coeff = coeffs[i];
 
 		coeff[0] = eps;
-		coeff[1] = 0;						 // f1
-		coeff[2] = 0;						 // -49050000; // ;  // f2:
-		coeff[3] = 1.0 / 3.22761; // f3
+		coeff[1] = 0;						   // f1
+		coeff[2] = 0;						   // f2
+		coeff[3] = 1.0 / froudeNo; // f3
 	}
 }

--- a/UserConfig.cmake
+++ b/UserConfig.cmake
@@ -11,28 +11,6 @@ set(CMAKE_VERBOSE_MAKEFILE FALSE)
 # set(AParMooN_GEO "2D" CACHE STRING "Change AParMooN_GEO, to select the Dimensio of the problem")
 set(AParMooN_GEO "3D" CACHE STRING "Change AParMooN_GEO, to select the Dimension of the problem")
 
-#...................................................................................................................................................
-# select this line accordingly to include your main program
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/2DPrograms/CD2D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model") 
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/2DPrograms/TCD2D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model") 
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/2D_Programs/TCD2D_Shell_ParMooN.C" CACHE STRING "Enter to select the Main file of the model") 
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/2DPrograms/NSE2D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/2DPrograms/TNSE2D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/3DPrograms/CD3D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/3DPrograms/TCD3D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/3DPrograms/NSE3D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking_MPI_15LPM.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking_MPI.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Main_Users/Thivin/HiPC_Paper.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/3DPrograms/TNSE3D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-#  set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/3D_Programs/NSE3D_Siminhale.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/FTLE_Computation.cpp" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/FTLE_COMPUTATION_withData.cpp" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/TNSE3D/thivin_TNSE3D.cpp" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/Sample_mesh_move_2d.cpp" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/2DPrograms/TBE2D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
-# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/ANNPrograms/ANN_SUPG.C" CACHE STRING "Enter to select the Main file of the model")
-
 # selection of architect type (LINUX64 MAC64 INTEL64 TYRONE64 CRAY64)
 set(AParMooN_ARCH "INTEL64" CACHE STRING "select the machine type")
 
@@ -41,28 +19,13 @@ set(AParMooN_PARALLEL_TYPE "SCUDA" CACHE STRING "select the parallel type")
 
 #  selection of program type (MPICH OPENMPI INTELMPI CRAYMPI MACMPI)
 set(AParMooN_MPI_IMPLEMENTATION "INTELMPI" CACHE STRING "select the MPI Implementation type")
- 
-# set the path to save the exe file ....................................................................................
-#.......................................................................................................................
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/aletnse3d" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/TCD2D" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/NSE3D" CACHE STRING "select the model")
-#  set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/TNSE2D_FTLE" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/TNSE2D" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/TNSE3D/fluid_test" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Fluid/test" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Fluid_Solutions_refined/" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Fluid_1LPM/" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Particle_Solutions_l_inf/" CACHE STRING "select the model")
-set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/Siminhale_Particle_PolyDisperse_15LPM_2/" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "/media/HDD/thivin/ITC/Output/HiPC_Paper/" CACHE STRING "select the model")
-set(AParMooN_OUTPUT_DIR_PATH "/home/thivin/ITC_Output/8_100k_final" CACHE STRING "select the model")
 
-# set(AParMooN_OUTPUT_DIR_PATH "" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/thivin3d" CACHE STRING "select the model")
-#set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/burger" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/cd1dANN" CACHE STRING "select the model")
-# set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/../ParMooN_Output/ANNRegression" CACHE STRING "select the model")
+# select this line accordingly to include your main program
+# set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/3DPrograms/TNSE3D_ParMooN.C" CACHE STRING "Enter to select the Main file of the model")
+set(AParMooN_MODEL "${PROJECT_SOURCE_DIR}/Main_Users/Thivin/3D_Programs/SiminhaleParticleTracking_MPI" CACHE STRING "Enter to select the Main file of the model")
+ 
+# set the path to save the exe file
+set(AParMooN_OUTPUT_DIR_PATH "${CMAKE_SOURCE_DIR}/Output/Particle/" CACHE STRING "select the model")
 
 set(USE_PARMOON_DEFINE -D__PRIVATE__)
 

--- a/include/FE/Particle.h
+++ b/include/FE/Particle.h
@@ -4,14 +4,19 @@
 #include <vector>
 #include <AllClasses.h>
 #include <FEFunction3D.h>
-#include <curand_kernel.h>
+
+#ifdef _CUDA
+	#include <curand_kernel.h>
+#endif
 
 #ifndef __Particle__
 #define __Particle__
 
-// typedef curandState RandomStateType;
-typedef curandStatePhilox4_32_10_t RandomStateType;
-// typedef curandStateMRG32k3a_t RandomStateType;
+#ifdef _CUDA
+	// typedef curandState RandomStateType;
+	typedef curandStatePhilox4_32_10_t RandomStateType;
+	// typedef curandStateMRG32k3a_t RandomStateType;
+#endif
 
 // Class of Mono Disperse Particles
 class TParticles

--- a/include/FE/Particle.h
+++ b/include/FE/Particle.h
@@ -1,12 +1,17 @@
-#include<vector>
-#include<string>
+#include <vector>
+#include <string>
 #include <map>
 #include <vector>
 #include <AllClasses.h>
 #include <FEFunction3D.h>
+#include <curand_kernel.h>
 
 #ifndef __Particle__
 #define __Particle__
+
+// typedef curandState RandomStateType;
+typedef curandStatePhilox4_32_10_t RandomStateType;
+// typedef curandStateMRG32k3a_t RandomStateType;
 
 // Class of Mono Disperse Particles
 class TParticles
@@ -343,10 +348,12 @@ class TParticles
           // deposited particles status
           int* d_m_is_deposited_particle;
 
-
           // Allocate memory for Column Index and Row Pointer for the adjacency matrix
           int* d_m_row_pointer;
           int* d_m_col_index;
+
+					// pseudo random states
+					RandomStateType* d_m_curand_states;
 
 
           // --- CUDA RELATED FUNCTIONS -- //

--- a/include/General/Database.h
+++ b/include/General/Database.h
@@ -424,6 +424,21 @@ struct TParaDB
   int RFB_SUBMESH_LAYERS;
 
   //======================================================================
+  /** parameters for particle deposition */
+  //======================================================================
+
+	double LENGTH_SCALE;
+	double VELOCITY_SCALE;
+	double PARTICLE_DIAMETER;
+	double PARTICLE_DENSITY;
+	double FLUID_DENSITY;
+	double FLUID_VISCOSITY;
+	int IS_PARTICLE_MONODISPERSE; 
+	int IS_PARTICLE_FUSED; 
+	int PARTICLE_RELEASE_NO;
+	int PARTICLE_RELEASE_INTERVAL;
+
+  //======================================================================
   /** parameters for slip with friction and penetration with resistance
       boundary conditions                                               */
   //======================================================================
@@ -1068,6 +1083,7 @@ struct TTimDB
   double CURRENTTIME;
   double CURRENTTIMESTEPLENGTH;
   double TIMESTEPLENGTH;
+	int TIMESTEPSPLIT;
   double INTERNAL_STARTTIME;
   double MIN_TIMESTEPLENGTH;
   double MAX_TIMESTEPLENGTH;

--- a/src/FE/Particle.C
+++ b/src/FE/Particle.C
@@ -293,19 +293,19 @@ TParticles::TParticles(int N_Particles_, double circle_x, double circle_y, doubl
 void TParticles::InitialiseParticleParameters(int N_Particles_)
 {
     // Density of the fluid
-    m_fluid_density = 1.1385; // kg/m^3
+		m_fluid_density = TDatabase::ParamDB->FLUID_DENSITY; // kg/m^3
 
     // Dynamic Viscosity of the fluid
-    m_fluid_dynamic_viscosity = 0.00001893; // Pa.s
+    m_fluid_dynamic_viscosity = TDatabase::ParamDB->FLUID_VISCOSITY; // Pa.s
 
     // mean free path
     m_lambda = 0.00000007; // m
 
     // resize particle diameter
-    m_particle_diameter.resize(N_Particles_, 4.3e-6); // earlier 10e-6   // [IMPORTANT] THE VALUE NEEDS TO BE CHANGED BELOW
+    m_particle_diameter.resize(N_Particles_, TDatabase::ParamDB->PARTICLE_DIAMETER);
 
      // resize density
-    m_particle_density.resize(N_Particles_, 914); // earlier 1266        // [IMPORTANT] THE VALUE NEEDS TO BE CHANGED BELOW
+    m_particle_density.resize(N_Particles_, TDatabase::ParamDB->PARTICLE_DENSITY);
 
     // Provide the mass fraction of the particles
     // f propylene glycol, glycerol, nicotine and water with their mass fractions being 52.6%, 28.1%, 1.9%, and 17.4%
@@ -317,26 +317,23 @@ void TParticles::InitialiseParticleParameters(int N_Particles_)
     std::vector<double> density_array = {1032.56, 1261, 1010, 1000};
 
     // Set all the particle sizes bsed on the function 
-    std::string particle_size_distribution = "monodisperse";  // or "monodisperse"
+    std::string particle_size_distribution = TDatabase::ParamDB->IS_PARTICLE_MONODISPERSE ? "monodisperse" : "polydisperse";
 
     // Set the polydisperse type
     // Fused will generate all particles with same density equivalent to the density difference of all particles. 
     // Seperate will generate particles with different densities
-    std::string polydisperse_type = "fused"; // or "fused"
+    std::string polydisperse_type = TDatabase::ParamDB->IS_PARTICLE_FUSED ? "fused" : "seperate";
 
     // check if the string equals to polydisperse
     if(particle_size_distribution == "polydisperse")
     {
         TParticles::GenerateParticleDiameterAndDensity(m_particle_diameter, m_particle_density, mass_fraction, density_array, 0.307 * 1e-6, 1.69* 1e-6);
 
-        
-
         if (polydisperse_type == "fused") {
             double density_sum = 0.0;
             for (int i = 0; i < mass_fraction.size(); i++) {
                 density_sum += mass_fraction[i] * density_array[i];
             }
-
             for (int i = 0; i < m_particle_density.size(); i++) {
                 m_particle_density[i] = density_sum;
             }
@@ -345,20 +342,16 @@ void TParticles::InitialiseParticleParameters(int N_Particles_)
     else
     {
         // HARDCODED_THIVIN For mono disperse particle with single density 
-        double density_mono = 1096; // DEHS from sininhale paper
+			double density_mono = TDatabase::ParamDB->PARTICLE_DENSITY;
         for (int i = 0; i < m_particle_density.size(); i++) {
             m_particle_density[i] = density_mono;
         }
-
         // HARDCODED_THIVIN particle size
-        double particle_size = 0.4e-6;
+        double particle_size = TDatabase::ParamDB->PARTICLE_DIAMETER;
         for (int i = 0; i < m_particle_diameter.size(); i++) {
             m_particle_diameter[i] = particle_size;
-            
         }
     }
-
-    
     
     // --- FOr Polydisperse Fused particle ---- //
     // rewrite all particle density to mass_fraction * density
@@ -1603,18 +1596,16 @@ void TParticles::detectStagnantParticles() {
 void TParticles::interpolateNewVelocity(double timeStep, TFEVectFunct3D *VelocityFEVectFunction, TFESpace3D* fespace)
 {
     // Constants required for computation
-    double densityFluid = 1.1385;
-    double densityParticle = 914; // earlier 1266
+		double densityFluid = TDatabase::ParamDB->FLUID_DENSITY;
+    double densityParticle = TDatabase::ParamDB->PARTICLE_DENSITY;
     double g_x = 0;
     double g_y = 0;
-    // double g_z = 1.0 / 51.6414;
     double g_z = 9.81;
 
-    double dynamicViscosityFluid = 0.00001893;
+    double dynamicViscosityFluid = TDatabase::ParamDB->FLUID_VISCOSITY;
     double lambda = 0.00000007;
 
-    // Particle Diameter = 8 Micrometers
-    double particleDiameter = 2.5e-6; // earlier 4e-6
+    double particleDiameter = TDatabase::ParamDB->PARTICLE_DIAMETER;
 
     double mass_particle = (Pi * pow(particleDiameter, 3) * densityParticle) / 6;
     double mass_div_dia = mass_particle / particleDiameter;
@@ -1647,9 +1638,9 @@ void TParticles::interpolateNewVelocity(double timeStep, TFEVectFunct3D *Velocit
     };
 
     // Here We ensure that the Particles are released in timely manner , in batches of 2000, every 10 time steps
-    int numParticlesReleasedPerTimeStep = 500;
+    int numParticlesReleasedPerTimeStep = TDatabase::ParamDB->PARTICLE_RELEASE_NO;
     int timeStepCounter = 0;
-    int timeStepInterval = 10;   // Release particles every n steps
+    int timeStepInterval = TDatabase::ParamDB->PARTICLE_RELEASE_INTERVAL;
     
     int actualTimeStep = (int) (TDatabase::TimeDB->CURRENTTIME / TDatabase::TimeDB->TIMESTEPLENGTH);
 
@@ -1989,9 +1980,9 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
 {
 
     // Here We ensure that the Particles are released in timely manner , in batches of 2000, every 10 time steps
-    int numParticlesReleasedPerTimeStep = 5000;
+    int numParticlesReleasedPerTimeStep = TDatabase::ParamDB->PARTICLE_RELEASE_NO;
     int timeStepCounter = 0;
-    int timeStepInterval = 100;   // Release particles every n steps
+    int timeStepInterval = TDatabase::ParamDB->PARTICLE_RELEASE_INTERVAL;
     
     int actualTimeStep = (int) (TDatabase::TimeDB->CURRENTTIME / TDatabase::TimeDB->TIMESTEPLENGTH);
 
@@ -2044,7 +2035,7 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
     m_StagnantParticlesCount = std::count(isStagnantParticle.begin(), isStagnantParticle.end(), 1);
 
     // Enable printing for the Output console once every 100 timesteps
-    if((actualTimeStep+1) % 100 ==0)
+    if((actualTimeStep+1) % (10 * TDatabase::TimeDB->TIMESTEPSPLIT) == 0)
     {
         double x_difference_position =  diff_dot_product(position_X,position_X_old);
         double y_difference_position =  diff_dot_product(position_Y,position_Y_old);
@@ -2059,37 +2050,27 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
         std::cout << std::setw(50) << std::left << "Ghost particles Accumulated" << " : " << std::setw(10) << std::right << m_ghostParticlesCount << std::endl;
         std::cout << std::setw(50) << std::left << "Stagnant particles Accumulated" << " : " << std::setw(10) << std::right << m_StagnantParticlesCount << std::endl;
     }
-    
-
-
-    // cout << "No of particles Deposited or Escaped: " << depositedCount << endl;
-    // cout << "percentage of particles Not Deposited : " << (double(N_Particles - depositedCount) / (double)N_Particles) * 100 << " % " << endl;
-    // cout << "Error particles Accumulaated : " << m_ErrorParticlesCount << endl;
 }
 #else
 void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D *VelocityFEVectFunction, TFESpace3D* fespace)
 {
-
     // time the function
     auto start = std::chrono::high_resolution_clock::now();
 
     // Constants required for computation
-    double densityFluid = 1.1385;
+    double densityFluid = TDatabase::ParamDB->FLUID_DENSITY;
     double g_x = 0;
     double g_y = 0;
     double g_z = 9.81;
-    double dynamicViscosityFluid = 0.00001893;
+    double dynamicViscosityFluid = TDatabase::ParamDB->FLUID_VISCOSITY;
     double lambda = 0.00000007;
     // Here We ensure that the Particles are released in timely manner , in batches of 2000, every 10 time steps
-    int numParticlesReleasedPerTimeStep = 50000;
+    int numParticlesReleasedPerTimeStep = TDatabase::ParamDB->PARTICLE_RELEASE_NO;
     int timeStepCounter = 0;
-    int timeStepInterval = 10;   // Release particles every n steps
+    int timeStepInterval = TDatabase::ParamDB->PARTICLE_RELEASE_INTERVAL;
 
     // Search Depth
     int searchDepth = 3;
-
-
-
 		auto inertialConstant = [&](double densityParticle, double particleDiameter)
 		{ return (3. / 4.) * (densityFluid / densityParticle) * (1 / particleDiameter); };
 
@@ -2113,15 +2094,10 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
         double Re_Particle = densityFluid * particleDiameter * fabs(fluidVel - particleVel) / dynamicViscosityFluid;
         double CD = (24 / Re_Particle) * (1 + 0.15 * pow(Re_Particle, 0.687));
         double CC = 1.0 + ((2 * lambda) / particleDiameter) * (1.257 + 0.4 * exp(-1.0 * ((1.1 * particleDiameter) / (2 * lambda))));
-        // CC = 1.0;
         return CD/CC;
-        // return 1;
     };
-
-
     
     int actualTimeStep = (int) (TDatabase::TimeDB->CURRENTTIME / TDatabase::TimeDB->TIMESTEPLENGTH);
-
 
     // release at first time step and at every 10th time step
     if(actualTimeStep % timeStepInterval == 0  || (m_ParticlesReleased ==0))
@@ -2141,9 +2117,7 @@ void TParticles::interpolateNewVelocity_Parallel(double timeStep, TFEVectFunct3D
     TFEFunction3D *FEFuncVelocityY = VelocityFEVectFunction->GetComponent(1);
     TFEFunction3D *FEFuncVelocityZ = VelocityFEVectFunction->GetComponent(2);
 
-
     cout << "PART RELEASED : " << m_ParticlesReleased <<endl;
-
     
     // Open a file to write the data based on the actual time step
     // std::string filename = "Debug_ParticleData_" + std::to_string(actualTimeStep) + ".csv";

--- a/src/FE/Particle.cu
+++ b/src/FE/Particle.cu
@@ -15,10 +15,13 @@
 
 #include <cuda.h>
 #include "helper_cuda.h"
+#include <math_constants.h>
 #include <AllClasses.h>
 #include <FEDatabase3D.h>
 #include "Particle.h"
 #include <cmath>
+
+#define MAX_THREAD_PER_BLOCK 128
 
 struct __device__ Vector3D_Cuda
 {
@@ -251,6 +254,34 @@ __device__ double cd_cc_cuda(double fluid_density,
     return cd/cc;
 }   
 
+// GPU Function to compute acceleration due to brownian force
+__device__ void brownian_acc(double fluid_density,
+														 double particle_diameter,
+														 double fluid_dynamic_viscosity,
+														 double lambda,
+														 double time_step,
+														 int tid,
+														 RandomStateType rand_state,
+														 double particle_mass,
+														 double *fbx,
+														 double *fby,
+														 double *fbz
+														 )
+{
+    double cc = 1.0 + ((2 * lambda) / particle_diameter) * (1.257 + 0.4 * exp(-1.0 * ((1.1 * particle_diameter) / (2 * lambda))));
+		double kb = 1.3806488e23; // Boltzmann constant (J/K)
+		double temp = 310; // temperature (K)
+		double d = (kb * temp * cc) / (3 * CUDART_PI_F * fluid_density * particle_diameter); // Brownian diffusivity
+
+		double gx = curand_normal_double(&rand_state);
+		double gy = curand_normal_double(&rand_state);
+		double gz = curand_normal_double(&rand_state);
+		double value = kb * temp * sqrt(2 / d * time_step) / particle_mass;
+		*fbx = gx * value;
+		*fby = gy * value;
+		*fbz = gz * value;
+}   
+
 // Function to set the sell and return the reference values
 // this function is HARD CODED for a tetrahedral cell with p2 finite element
 // HARDCODED - THIVIN
@@ -425,6 +456,7 @@ __global__ void Interpolate_Velocity_CUDA(  // cell Vertices
                                             int* d_m_is_error_particle,
                                             int* d_m_is_stagnant_particle,
                                             int* d_m_is_ghost_particle,
+																						RandomStateType *d_m_curand_states,
 
                                             // row pointer and column indices of the adjacency matrix
                                             int* d_m_row_pointer,
@@ -461,38 +493,44 @@ __global__ void Interpolate_Velocity_CUDA(  // cell Vertices
         // }
 
         // Call the funciton to obtain the velocity at the given point
-        struct Vector3D_Cuda interpolated_velocities = Obtain_velocity_at_a_point(cell_no,
-                                    tid,
-                                           d_m_particle_position_x,
-                                           d_m_particle_position_y,
-                                           d_m_particle_position_z,
-                                           d_m_particle_velocity_x,
-                                           d_m_particle_velocity_y,
-                                           d_m_particle_velocity_z,
-                                           d_m_cell_vertices_x,
-                                           d_m_cell_vertices_y,
-                                           d_m_cell_vertices_z,
-                                           d_m_velocity_nodal_values_x,
-                                             d_m_velocity_nodal_values_y,
-                                                d_m_velocity_nodal_values_z,
-                                           d_m_global_dof_indices,
-                                           d_m_begin_indices);
+        struct Vector3D_Cuda interpolated_velocities =
+					Obtain_velocity_at_a_point(cell_no,
+																		 tid,
+																		 d_m_particle_position_x,
+																		 d_m_particle_position_y,
+																		 d_m_particle_position_z,
+																		 d_m_particle_velocity_x,
+																		 d_m_particle_velocity_y,
+																		 d_m_particle_velocity_z,
+																		 d_m_cell_vertices_x,
+																		 d_m_cell_vertices_y,
+																		 d_m_cell_vertices_z,
+																		 d_m_velocity_nodal_values_x,
+																		 d_m_velocity_nodal_values_y,
+																		 d_m_velocity_nodal_values_z,
+																		 d_m_global_dof_indices,
+																		 d_m_begin_indices);
 
         // USe the interpolated velocity functions to call the Calculate_Updated_Position_CUDA function 
         // This function updates the position array automatically
         // a Double can only be declated as a double * in cuda, due to malloc, so 
         // we will convert it to double value here.
         double fluid_density = *d_m_fluid_density;
+        double particle_diameter = d_m_particle_diameter[tid];
         double dynamic_viscosity_fluid = *d_m_dynamic_viscosity_fluid;
         double lambda = *d_m_lambda;
         double gravity_x = *d_m_gravity_x;
         double gravity_y = *d_m_gravity_y;
         double gravity_z = *d_m_gravity_z;
-
-        //  if (tid == 0)
-        // {
-        //     printf("GPU : %f %f %f\n", interpolated_velocities.x, interpolated_velocities.y, interpolated_velocities.z);
-        // }
+				double particle_mass = *d_m_particle_density * CUDART_PI_F * pow(particle_diameter, 3) / 6;
+				double fbx = 0, fby = 0, fbz = 0;
+				RandomStateType rand_state = d_m_curand_states[tid];
+				// TODO: exclude brownian motion as it fluctuates a lot
+				// brownian_acc(fluid_density,
+				// 						 particle_diameter,
+				// 						 dynamic_viscosity_fluid,
+				// 						 lambda, time_step, tid, rand_state,
+				// 						 particle_mass, &fbx, &fby, &fbz);
 
         // Calculate cd_cc
         double cd_cc_x = 0.0;
@@ -504,31 +542,29 @@ __global__ void Interpolate_Velocity_CUDA(  // cell Vertices
         double fluid_velocity_y = interpolated_velocities.y;
         double fluid_velocity_z = interpolated_velocities.z;
 
-        
-
         cd_cc_x = cd_cc_cuda(fluid_density,
-                            d_m_particle_diameter[tid],
-                            fluid_velocity_x,
-                            d_m_particle_velocity_x[tid],
-                            dynamic_viscosity_fluid,
-                            lambda
-                            );
+                             d_m_particle_diameter[tid],
+                             fluid_velocity_x,
+                             d_m_particle_velocity_x[tid],
+                             dynamic_viscosity_fluid,
+                             lambda
+                             );
         
         cd_cc_y = cd_cc_cuda(fluid_density,
-                                d_m_particle_diameter[tid],
-                                fluid_velocity_y,
-                                d_m_particle_velocity_y[tid],
-                                dynamic_viscosity_fluid,
-                                lambda
-                                );
+                             d_m_particle_diameter[tid],
+                             fluid_velocity_y,
+                             d_m_particle_velocity_y[tid],
+                             dynamic_viscosity_fluid,
+                             lambda
+                             );
         
         cd_cc_z = cd_cc_cuda(fluid_density,
-                                d_m_particle_diameter[tid],
-                                fluid_velocity_z,
-                                d_m_particle_velocity_z[tid],
-                                dynamic_viscosity_fluid,
-                                lambda
-                                );  
+                             d_m_particle_diameter[tid],
+                             fluid_velocity_z,
+                             d_m_particle_velocity_z[tid],
+                             dynamic_viscosity_fluid,
+                             lambda
+                             );  
         
         // // FInd the minimum cd_cc
         // double cd_cc_min = cd_cc_x;
@@ -551,12 +587,15 @@ __global__ void Interpolate_Velocity_CUDA(  // cell Vertices
 
         rhs_x = inertial_constant * cd_cc_x * abs(fluid_velocity_x - d_m_particle_velocity_x[tid]) * (fluid_velocity_x - d_m_particle_velocity_x[tid]);
         rhs_x += gravity_x * (fluid_density - d_m_particle_density[tid]) / d_m_particle_density[tid];
+				rhs_x += fbx;
 
         rhs_y = inertial_constant * cd_cc_y * abs(fluid_velocity_y - d_m_particle_velocity_y[tid]) * (fluid_velocity_y - d_m_particle_velocity_y[tid]);
         rhs_y += gravity_y * (fluid_density - d_m_particle_density[tid]) / d_m_particle_density[tid];
+				rhs_y += fby;
 
         rhs_z = inertial_constant * cd_cc_z * abs(fluid_velocity_z - d_m_particle_velocity_z[tid]) * (fluid_velocity_z - d_m_particle_velocity_z[tid]);
         rhs_z += gravity_z * (fluid_density - d_m_particle_density[tid]) / d_m_particle_density[tid];
+				rhs_z += fbz;
 
         //  if (tid == 0)
         // {
@@ -968,6 +1007,12 @@ __global__ void DetectStagnantParticles_CUDA(double* d_m_particle_position_x,
         }
 }
 
+__global__ void setup_curand(RandomStateType *state)
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
+    curand_init(1234, id, 0, &state[id]);
+}
+
 void TParticles::SetupCudaDataStructures(TFESpace3D* fespace)
 {
     // get the collection of cells from the fespace
@@ -1207,6 +1252,18 @@ void TParticles::SetupCudaDataStructures(TFESpace3D* fespace)
         }
     }
 
+		// ---------------  Setup Pseudo Random Number Generator ----------------
+
+		// Allocate memory for curand states
+    checkCudaErrors(cudaMalloc((void**)&d_m_curand_states, N_Particles * sizeof(RandomStateType)));
+
+		// initialize curand states
+    int C_NUM_BLOCKS = std::ceil(double(N_Particles)/MAX_THREAD_PER_BLOCK);
+
+    dim3 dimGrid(C_NUM_BLOCKS);
+    dim3 dimBlock(N_Particles);
+
+		setup_curand<<<dimGrid, dimBlock>>>(d_m_curand_states);
     
    
     // ----- ALLOCATE MEMORY IN GPU FOR ALL THE DEVICE VARIABLES -----
@@ -1510,7 +1567,6 @@ void TParticles::CD_CC_Cuda()
 // Host wrapper for performing the velocity interpolation at every time step
 void TParticles::InterpolateVelocityHostWrapper(double time_step,int N_Particles_released,int N_DOF,int N_Cells)
 {
-    int MAX_THREAD_PER_BLOCK = 128;
     int N_threads; 
 
     if(N_Particles_released >= MAX_THREAD_PER_BLOCK) 
@@ -1521,11 +1577,10 @@ void TParticles::InterpolateVelocityHostWrapper(double time_step,int N_Particles
     
     int C_NUM_BLOCKS = std::ceil(double(N_Particles_released)/MAX_THREAD_PER_BLOCK);
 
+    dim3 dimGrid(C_NUM_BLOCKS);
+    dim3 dimBlock(N_threads);
 
-   dim3 dimGrid(C_NUM_BLOCKS);
-   dim3 dimBlock(N_threads);
-
-   // time the kernel
+    // time the kernel
     cudaEvent_t start, stop;
     cudaEventCreate(&start);
     cudaEventRecord(start, 0);
@@ -1587,6 +1642,7 @@ void TParticles::InterpolateVelocityHostWrapper(double time_step,int N_Particles
                                                     d_m_is_error_particle,
                                                     d_m_is_stagnant_particle,
                                                     d_m_is_ghost_particle,
+																										d_m_curand_states,
                                                     d_m_row_pointer,
                                                     d_m_col_index,
                                                     N_Cells,
@@ -1660,7 +1716,6 @@ void TParticles::InterpolateVelocityHostWrapper(double time_step,int N_Particles
 // Host wrapper for detecting stagnant particles
 void TParticles::DetectStagnantParticlesHostWrapper(int N_Particles_released)
 {
-    int MAX_THREAD_PER_BLOCK = 32;
     int N_threads; 
 
     if(N_Particles_released >= MAX_THREAD_PER_BLOCK) 

--- a/src/General/Database.C
+++ b/src/General/Database.C
@@ -446,6 +446,17 @@ void TDatabase::SetDefaultParameters()
   ParamDB->DEFECT_CORRECTION_TYPE = 0;
   ParamDB->CELL_MEASURE = 0;
 
+	ParamDB->LENGTH_SCALE = 0.02;
+	ParamDB->VELOCITY_SCALE = 3.183098862; // 60 LPM
+	ParamDB->PARTICLE_DIAMETER = 4.3e-6;
+	ParamDB->PARTICLE_DENSITY = 914;
+	ParamDB->FLUID_DENSITY = 1.1385;
+	ParamDB->FLUID_VISCOSITY = 0.00001893;
+	ParamDB->IS_PARTICLE_MONODISPERSE = 1; 
+	ParamDB->IS_PARTICLE_FUSED = 1; 
+	ParamDB->PARTICLE_RELEASE_NO = 5000;
+	ParamDB->PARTICLE_RELEASE_INTERVAL = 100;
+
   ParamDB->FACE_SIGMA = 1;
   ParamDB->WEAK_BC_SIGMA = 1;
   ParamDB->WEAK_BC = 0;
@@ -777,6 +788,7 @@ void TDatabase::SetDefaultParameters()
   TimeDB->CURRENTTIME = 0;
   TimeDB->CURRENTTIMESTEPLENGTH = 1;
   TimeDB->TIMESTEPLENGTH = 1;
+  TimeDB->TIMESTEPSPLIT = 1;
   TimeDB->MIN_TIMESTEPLENGTH = 1E-4;
   TimeDB->MAX_TIMESTEPLENGTH = 0.5;
   TimeDB->TIMESTEPLENGTH_TOL = 1e-3;
@@ -1407,6 +1419,17 @@ void TDatabase::WriteParamDB(char *ExecutedFile)
   OutFile << "WEAK_BC_SIGMA: " << ParamDB->WEAK_BC_SIGMA << endl;
   OutFile << "WEAK_BC: " << ParamDB->WEAK_BC << endl;
 
+	OutFile << "LENGTH_SCALE: " << ParamDB->LENGTH_SCALE << endl;
+	OutFile << "VELOCITY_SCALE: " << ParamDB->VELOCITY_SCALE << endl;
+	OutFile << "PARTICLE_DIAMETER: " << ParamDB->PARTICLE_DIAMETER << endl;
+	OutFile << "PARTICLE_DENSITY: " << ParamDB->PARTICLE_DENSITY << endl;
+	OutFile << "FLUID_DENSITY: " << ParamDB->FLUID_DENSITY << endl;
+	OutFile << "FLUID_VISCOSITY: " << ParamDB->FLUID_VISCOSITY << endl;
+	OutFile << "IS_PARTICLE_MONODISPERSE: " << ParamDB->IS_PARTICLE_MONODISPERSE << endl; 
+	OutFile << "IS_PARTICLE_FUSED: " << ParamDB->IS_PARTICLE_FUSED << endl; 
+	OutFile << "PARTICLE_RELEASE_NO: " << ParamDB->PARTICLE_RELEASE_NO << endl;
+	OutFile << "PARTICLE_RELEASE_INTERVAL: " << ParamDB->PARTICLE_RELEASE_INTERVAL << endl;
+
   OutFile << "RE_NR: " << ParamDB->RE_NR << endl;
   OutFile << "RA_NR: " << ParamDB->RA_NR << endl;
   OutFile << "ROSSBY_NR: " << ParamDB->ROSSBY_NR << endl;
@@ -1836,6 +1859,7 @@ void TDatabase::WriteTimeDB()
   OutFile << "CURRENTTIME: " << TimeDB->CURRENTTIME << endl;
   OutFile << "CURRENTTIMESTEPLENGTH: " << TimeDB->CURRENTTIMESTEPLENGTH << endl;
   OutFile << "TIMESTEPLENGTH: " << TimeDB->TIMESTEPLENGTH << endl;
+  OutFile << "TIMESTEPSPLIT: " << TimeDB->TIMESTEPSPLIT << endl;
   OutFile << "MIN_TIMESTEPLENGTH: " << TimeDB->MIN_TIMESTEPLENGTH << endl;
   OutFile << "MAX_TIMESTEPLENGTH: " << TimeDB->MAX_TIMESTEPLENGTH << endl;
   OutFile << "TIMESTEPLENGTH_TOL: " << TimeDB->TIMESTEPLENGTH_TOL << endl;

--- a/src/General/ReadParam.C
+++ b/src/General/ReadParam.C
@@ -482,6 +482,57 @@ int TDomain::ReadParam(char *ParamFile)
       N_Param++;
     }
 
+		if (!strcmp(line, "LENGTH_SCALE:"))
+		{
+			dat >> TDatabase::ParamDB->LENGTH_SCALE;
+			N_Param++;
+		}
+		if (!strcmp(line, "VELOCITY_SCALE:"))
+		{
+			dat >> TDatabase::ParamDB->VELOCITY_SCALE;
+			N_Param++;
+		}
+		if (!strcmp(line, "PARTICLE_DIAMETER:"))
+		{
+			dat >> TDatabase::ParamDB->PARTICLE_DIAMETER;
+			N_Param++;
+		}
+		if (!strcmp(line, "PARTICLE_DENSITY:"))
+		{
+			dat >> TDatabase::ParamDB->PARTICLE_DENSITY;
+			N_Param++;
+		}
+		if (!strcmp(line, "FLUID_DENSITY:"))
+		{
+			dat >> TDatabase::ParamDB->FLUID_DENSITY;
+			N_Param++;
+		}
+		if (!strcmp(line, "FLUID_VISCOSITY:"))
+		{
+			dat >> TDatabase::ParamDB->FLUID_VISCOSITY;
+			N_Param++;
+		}
+		if (!strcmp(line, "IS_PARTICLE_MONODISPERSE:"))
+		{
+			dat >> TDatabase::ParamDB->IS_PARTICLE_MONODISPERSE; 
+			N_Param++;
+		}
+		if (!strcmp(line, "IS_PARTICLE_FUSED:"))
+		{
+			dat >> TDatabase::ParamDB->IS_PARTICLE_FUSED; 
+			N_Param++;
+		}
+		if (!strcmp(line, "PARTICLE_RELEASE_NO:"))
+		{
+			dat >> TDatabase::ParamDB->PARTICLE_RELEASE_NO;
+			N_Param++;
+		}
+		if (!strcmp(line, "PARTICLE_RELEASE_INTERVAL:"))
+		{
+			dat >> TDatabase::ParamDB->PARTICLE_RELEASE_INTERVAL;
+			N_Param++;
+		}
+
     if (!strcmp(line, "CELL_MEASURE:"))
     {
 	dat >> TDatabase::ParamDB->CELL_MEASURE;
@@ -2260,6 +2311,11 @@ int TDomain::ReadParam(char *ParamFile)
     if (!strcmp(line, "TIMESTEPLENGTH:"))
     {
       dat >> TDatabase::TimeDB->TIMESTEPLENGTH;
+      N_Param++;
+    }
+    if (!strcmp(line, "TIMESTEPSPLIT:"))
+    {
+      dat >> TDatabase::TimeDB->TIMESTEPSPLIT;
       N_Param++;
     }
     if (!strcmp(line, "MIN_TIMESTEPLENGTH:"))


### PR DESCRIPTION
`Database.C`, `Database.h`, `ReadParam.C`:
- Add the following new variables in ParamDB/TimeDB
  - LENGTH_SCALE
  - VELOCITY_SCALE
  - PARTICLE_DIAMETER
  - PARTICLE_DENSITY
  - FLUID_DENSITY
  - FLUID_VISCOSITY
  - IS_PARTICLE_MONODISPERSE
  - IS_PARTICLE_FUSED
  - PARTICLE_RELEASE_NO
  - PARTICLE_RELEASE_INTERVAL
  - TIMESTEPSPLIT

`siminhale2.h`
- Make `Froude No:` dynamic based on velocity and length scale

`SiminhaleParticleTracking_MPI.C`, `Particle.C`
- Use data from ParamDB/TimeDB instead of hardcoded data
- Remove extra newlines
- Indent the code

`UserConfig.cmake`
- Remove unrequired comments